### PR TITLE
Non tagliare le scritte nelle <select>.

### DIFF
--- a/public/css/custom-bs.css
+++ b/public/css/custom-bs.css
@@ -344,7 +344,6 @@ input, textarea, select { margin: 0px 2px 20px 2px; color: #000; }
 input  { background-color: #fff; border: solid 1px #aaa; padding: 2px 6px; font-size: 16px;}
 textarea { border:1px solid #aaa; padding:3px; font-size:11pt; margin-bottom: 5px;}
 select {
-    height: 28px;
     padding: 6px 12px;
     color: #555;
     background-color: #fff;


### PR DESCRIPTION
Nei form, il testo delle <select> è tagliato a circa metà altezza.
Questo perché il font è più alto della casella di testo che ha una
altezza fissa di 28px.

Con questa patch rimuovo dal CSS l'altezza fissa in modo che si
adatti automaticamente all'altezza dei caratteri.

Il problema è che così l'altezza della casella non è più uguale a
quella delle caselle di testo semplici, quindi graficamente il
form è meno omogeneo. Ma per ora mi sembra più importante
rendere più leggibili le scritte.

In futuro vorrei lavorare un po' di più sulla grafica e questo
problema non ci sarà più.