### PR TITLE
Usa classe+id per trovare elementi nelle categorie.

### DIFF
--- a/resources/Model/Categorie.php
+++ b/resources/Model/Categorie.php
@@ -98,12 +98,19 @@ class Model_Categorie extends Model_AF_AbstractHandlerCoR
         // ADD Cat
         $catRoot = $this->getRoot();
         $cat = $this->_initCat($v, $catRoot);
-        if(!is_null($cat)) {
+        if(!is_null($cat))
+        {
             // ADD SubCat to Cat
             $subcat = $this->_initSubCat($v, $cat);
-            if ($subcat) {
+            if ($subcat)
+            {
+                // I prodotti sono solo in sottocategorie
                 $this->_initProdotto($v, $subcat);
-                $this->_initProduttore($v, $subcat);
+            }
+            else
+            {
+                // I produttori sono solo in categorie
+                $this->_initProduttore($v, $cat);
             }
         }
     }
@@ -170,7 +177,7 @@ class Model_Categorie extends Model_AF_AbstractHandlerCoR
      * @param stdClass $v values
      * @param Model_Categorie_Element $subcat
      */
-    private function _initProduttore(stdClass $v, Model_Categorie_SubcatElement $subcat)
+    private function _initProduttore(stdClass $v, Model_Categorie_CatElement $subcat)
     {
         if(isset($v->idproduttore)) {
             if (is_null($subcat->getProduttoreById($v->idproduttore))) {

--- a/resources/Model/Categorie.php
+++ b/resources/Model/Categorie.php
@@ -5,7 +5,7 @@
 class Model_Categorie extends Model_AF_AbstractHandlerCoR
 {
     /**
-     * @var Model_Categorie
+     * @var Model_Categorie_CatElement
      */
     protected $_categorie = null;
 
@@ -26,7 +26,7 @@ class Model_Categorie extends Model_AF_AbstractHandlerCoR
     
     /**
      * get Root Categorie composite object
-     * @return Model_Categorie
+     * @return Model_Categorie_CatElement
      */
     public function getRoot()
     {
@@ -101,14 +101,9 @@ class Model_Categorie extends Model_AF_AbstractHandlerCoR
         if(!is_null($cat)) {
             // ADD SubCat to Cat
             $subcat = $this->_initSubCat($v, $cat);
-            // ADD PRODUCTS & PRODUTTORE to SubCat or Cat (ONLY if they exist)
-            if(!is_null($subcat)) 
-            {
+            if ($subcat) {
                 $this->_initProdotto($v, $subcat);
                 $this->_initProduttore($v, $subcat);
-            } else {
-                $this->_initProdotto($v, $cat);
-                $this->_initProduttore($v, $cat);
             }
         }
     }
@@ -116,17 +111,19 @@ class Model_Categorie extends Model_AF_AbstractHandlerCoR
     /**
      * add CAT to the Composite TREE
      * @param stdClass $v values
-     * @return null
+     * @return mixed (null|Model_Categorie_CatElement)
      */
-    private function _initCat(stdClass $v, Model_Categorie_Element $cat)
+    private function _initCat(stdClass $v, Model_Categorie_CatElement $root)
     {
         if(isset($v->idcat)) {
-            if(is_null($cat->getChild($v->idcat))) {
+            $cat = $root->getCatById($v->idcat);
+            if(is_null($cat)) {
                 // ADD CATEGORY Element
                 $cn = isset($v->categoria) ? $v->categoria : "";
-                $cat->add(new Model_Categorie_CatElement($v->idcat, $cn));
+                $cat = new Model_Categorie_CatElement($v->idcat, $cn);
+                $root->add($cat);
             }
-            return $cat->getChild($v->idcat);
+            return $cat;
         }
         return null;
     }
@@ -134,18 +131,20 @@ class Model_Categorie extends Model_AF_AbstractHandlerCoR
     /**
      * add SUBCAT to the Composite tree
      * @param stdClass $v values
-     * @param Model_Categorie_Element $cat
-     * @return mixed (null|Model_Categorie_Element)
+     * @param Model_Categorie_CatElement $cat
+     * @return mixed (null|Model_Categorie_SubcatElement)
      */
-    private function _initSubCat(stdClass $v, Model_Categorie_Element $cat)
+    private function _initSubCat(stdClass $v, Model_Categorie_CatElement $cat)
     {
         if(isset($v->idsubcat)) {
-            if(is_null($cat->getChild($v->idsubcat))) {
+            $subcat = $cat->getSubCatById($v->idsubcat);
+            if(is_null($subcat)) {
                 // ADD SUB-CATEGORY Element
                 $scn = isset($v->categoria_sub) ? $v->categoria_sub : "";
-                $cat->add(new Model_Categorie_SubcatElement($v->idsubcat, $scn));
+                $subcat = new Model_Categorie_SubcatElement($v->idsubcat, $scn);
+                $cat->add($subcat);
             }
-            return $cat->getChild($v->idsubcat);
+            return $subcat;
         }
         return null;
     }
@@ -154,38 +153,32 @@ class Model_Categorie extends Model_AF_AbstractHandlerCoR
      * add PRODOTTO to the Composite tree
      * @param stdClass $v values
      * @param Model_Categorie_Element $subcat
-     * @return mixed (null|Model_Categorie_Element)
      */
-    private function _initProdotto(stdClass $v, Model_Categorie_Element $subcat)
+    private function _initProdotto(stdClass $v, Model_Categorie_SubcatElement $subcat)
     {
         if(isset($v->idprodotto)) {
-            if(is_null($subcat->getChild($v->idprodotto))) {
-                // ADD SUB-CATEGORY Element
+            if (is_null($subcat->getProdottoById($v->idprodotto))) {
+                // ADD PRODOTTO Element
                 $scp = isset($v->descrizione_prodotto) ? $v->descrizione_prodotto : "";
                 $subcat->add(new Model_Categorie_ProdottoElement($v->idprodotto, $scp));
             }
-            return $subcat->getChild($v->idprodotto);
         }
-        return null;
     }
     
     /**
      * add PRODUTTORE to the Composite tree
      * @param stdClass $v values
      * @param Model_Categorie_Element $subcat
-     * @return mixed (null|Model_Categorie_Element)
      */
-    private function _initProduttore(stdClass $v, Model_Categorie_Element $subcat)
+    private function _initProduttore(stdClass $v, Model_Categorie_SubcatElement $subcat)
     {
         if(isset($v->idproduttore)) {
-            if(is_null($subcat->getChild($v->idproduttore))) {
-                // ADD SUB-CATEGORY Element
+            if (is_null($subcat->getProduttoreById($v->idproduttore))) {
+                // ADD PRODUTTORE Element
                 $scp = isset($v->ragsoc_produttore) ? $v->ragsoc_produttore : "";
                 $subcat->add(new Model_Categorie_ProduttoreElement($v->idproduttore, $scp));
             }
-            return $subcat->getChild($v->idproduttore);
         }
-        return null;
     }
             
 }

--- a/resources/Model/Categorie/CatElement.php
+++ b/resources/Model/Categorie/CatElement.php
@@ -35,6 +35,28 @@ class Model_Categorie_CatElement
         }
         return $ar;
     }
-    
-    
+
+    public function getCatById($id)
+    {
+        foreach($this->createIterator() as $ch)
+        {
+            if($ch instanceof Model_Categorie_CatElement && $ch->getId() === $id)
+            {
+                return $ch;
+            }
+        }
+        return null;
+    }
+
+    public function getSubCatById($id)
+    {
+        foreach($this->createIterator() as $ch)
+        {
+            if($ch instanceof Model_Categorie_SubcatElement && $ch->getId() === $id)
+            {
+                return $ch;
+            }
+        }
+        return null;
+    }
 }

--- a/resources/Model/Categorie/CatElement.php
+++ b/resources/Model/Categorie/CatElement.php
@@ -59,4 +59,16 @@ class Model_Categorie_CatElement
         }
         return null;
     }
+    
+    public function getProduttoreById($id)
+    {
+        foreach($this->createIterator() as $ch)
+        {
+            if($ch instanceof Model_Categorie_ProduttoreElement && $ch->getId() === $id)
+            {
+                return $ch;
+            }
+        }
+        return null;
+    }
 }

--- a/resources/Model/Categorie/SubcatElement.php
+++ b/resources/Model/Categorie/SubcatElement.php
@@ -53,4 +53,25 @@ class Model_Categorie_SubcatElement
         return $ar;
     }
     
+    public function getProdottoById($id)
+    {
+        foreach($this->createIterator() as $ch)
+        {
+            if($ch instanceof Model_Categorie_ProdottoElement && $ch->getId() === $id) {
+                return $ch;
+            }
+        }
+        return null;
+    }
+    
+    public function getProduttoreById($id)
+    {
+        foreach($this->createIterator() as $ch)
+        {
+            if($ch instanceof Model_Categorie_ProduttoreElement && $ch->getId() === $id) {
+                return $ch;
+            }
+        }
+        return null;
+    }
 }

--- a/resources/Model/Categorie/SubcatElement.php
+++ b/resources/Model/Categorie/SubcatElement.php
@@ -57,18 +57,8 @@ class Model_Categorie_SubcatElement
     {
         foreach($this->createIterator() as $ch)
         {
-            if($ch instanceof Model_Categorie_ProdottoElement && $ch->getId() === $id) {
-                return $ch;
-            }
-        }
-        return null;
-    }
-    
-    public function getProduttoreById($id)
-    {
-        foreach($this->createIterator() as $ch)
-        {
-            if($ch instanceof Model_Categorie_ProduttoreElement && $ch->getId() === $id) {
+            if($ch instanceof Model_Categorie_ProdottoElement && $ch->getId() === $id)
+            {
                 return $ch;
             }
         }


### PR DESCRIPTION
L'id non è univoco tra le classi, perché è solo un seriale. Quindi,
quando verifico se un prodotto o subcategoria è presente in una lista
composita, non è sufficiente verificare l'id, bisogna verificare anche
la classe dell'oggetto perché l'id potrebbe essere uguale.

Fixes iGruppi/iGruppi#53

ATTENZIONE: questa PR annulla la precedente iGruppi/iGruppi#55