### PR TITLE
Dettaglio ordine ignora prodotto se idprodotto==iduser

### DIFF
--- a/resources/Model/Ordini/Calcoli/Utenti.php
+++ b/resources/Model/Ordini/Calcoli/Utenti.php
@@ -103,7 +103,7 @@ class Model_Ordini_Calcoli_Utenti
                             }
                             // set Products
                             $idprodotto = $prodotto->getIdProdotto();
-                            if(!isset($this->_arProdUtenti[$idprodotto])) {
+                            if(!isset($this->_arProdUtenti[$iduser]["prodotti"][$idprodotto])) {
                                 $this->_arProdUtenti[$iduser]["prodotti"][$idprodotto] = $prodotto;
                             }
                         }


### PR DESCRIPTION
Il test per verificare se un prodotto è stato già incluso nel dettaglio
ordine, viene fatto su `iduser` invece di `idprodotto`. Quindi i
prodotti con `idprodotto == iduser` non vengono inclusi.

Per ora ho corretto il test, ma in realtà sono dell'idea che questo test
dovrebbe servire per segnalare un errore, non per decidere se includere
o no un prodotto. Non mi viene in mente una buona ragione per non
includere un prodotto nella lista. Se non deve comparire due volte
allora penso sia preferibile segnalarlo invece di ignorarlo.

ATTENZIONE: questa PR annulla la precedente iGruppi/iGruppi#55